### PR TITLE
Keep timer running even when window isn't at focus

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
             "default": 5,
             "description": "How many seconds after last action counter freezes"
           },
-          "coding-timer.onlyWhenTyping": {
+          "coding-timer.onlyWhenFocused": {
             "type": "boolean",
             "default": true,
-            "description": "Keep timer running even when the editor is not focused"
+            "description": "Keep timer running only when the editor is at focus"
           },
           "coding-timer.persistence": {
             "type": "string",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,11 @@
             "default": 5,
             "description": "How many seconds after last action counter freezes"
           },
+          "coding-timer.onlyWhenTyping": {
+            "type": "boolean",
+            "default": true,
+            "description": "Keep timer running even when the editor is not focused"
+          },
           "coding-timer.persistence": {
             "type": "string",
             "enum": [

--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
             "default": 5,
             "description": "How many seconds after last action counter freezes"
           },
-          "coding-timer.onlyWhenFocused": {
+          "coding-timer.freezeOnWindowBlur": {
             "type": "boolean",
             "default": true,
-            "description": "Keep timer running only when the editor is at focus"
+            "description": "Freeze timer on window focus loss"
           },
           "coding-timer.persistence": {
             "type": "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ export function activate(context: vscode.ExtensionContext) {
     Timeout.reset();
   });
   vscode.window.onDidChangeWindowState((e) => {
-    if ( Settings.getOnlyWhenTyping && !e.focused) {
+    if ( Settings.getOnlyWhenFocused && !e.focused) {
       Timer.freeze();
     }
   });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import { Timeout, Timer } from "./timer";
 import { StatusBarItem } from "./status-bar";
 import { Storage } from "./storage";
+import { Settings } from "./settings";
 
 export function activate(context: vscode.ExtensionContext) {
   StatusBarItem.init();
@@ -13,7 +14,7 @@ export function activate(context: vscode.ExtensionContext) {
     Timeout.reset();
   });
   vscode.window.onDidChangeWindowState((e) => {
-    if (!e.focused) {
+    if ( Settings.getOnlyWhenTyping && !e.focused) {
       Timer.freeze();
     }
   });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ export function activate(context: vscode.ExtensionContext) {
     Timeout.reset();
   });
   vscode.window.onDidChangeWindowState((e) => {
-    if ( Settings.getOnlyWhenFocused && !e.focused) {
+    if ( Settings.getFreezeOnWindowBlur() && !e.focused) {
       Timer.freeze();
     }
   });

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -12,7 +12,7 @@ export const Settings = {
   getPersistance: (): PersistenceType =>
     vscode.workspace.getConfiguration("coding-timer").get("persistance") ??
     PersistenceType.DAY_TO_DAY,
-  getOnlyWhenTyping: (): boolean => 
-  vscode.workspace.getConfiguration("coding-timer").get("onlyWhenTyping") ?? true,
+  getOnlyWhenFocused: (): boolean => 
+  vscode.workspace.getConfiguration("coding-timer").get("onlyWhenFocused") ?? true,
   
 };

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -12,4 +12,7 @@ export const Settings = {
   getPersistance: (): PersistenceType =>
     vscode.workspace.getConfiguration("coding-timer").get("persistance") ??
     PersistenceType.DAY_TO_DAY,
+  getOnlyWhenTyping: (): boolean => 
+  vscode.workspace.getConfiguration("coding-timer").get("onlyWhenTyping") ?? true,
+  
 };

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -12,7 +12,7 @@ export const Settings = {
   getPersistance: (): PersistenceType =>
     vscode.workspace.getConfiguration("coding-timer").get("persistance") ??
     PersistenceType.DAY_TO_DAY,
-  getOnlyWhenFocused: (): boolean => 
-  vscode.workspace.getConfiguration("coding-timer").get("onlyWhenFocused") ?? true,
+  getFreezeOnWindowBlur: (): boolean => 
+  vscode.workspace.getConfiguration("coding-timer").get("freezeOnWindowBlur") ?? true,
   
 };


### PR DESCRIPTION
**Code not tested** 

Added a toggle in extension settings to enable/disable "the timer will only run when editor is at focus".

Assuming that this pr works as intended: if the toggle is switched off, the timer should stay running in case other parts of VSCode are at focus (terminal, file explorer, debugger, etc.), and also in the case of VSCode window is minimized.